### PR TITLE
Allow $properties to be passed to construct

### DIFF
--- a/lib/CybsNameValuePairClient.php
+++ b/lib/CybsNameValuePairClient.php
@@ -11,9 +11,11 @@ include 'CybsClient.php';
 class CybsNameValuePairClient extends CybsClient
 {
 
-    function __construct($options=array())
+    function __construct($options=array(), $properties=array())
     {
-        $properties = parse_ini_file('cybs.ini');
+        if (empty($properties)) {
+            $properties = parse_ini_file('cybs.ini');
+        }
         parent::__construct($options, $properties, true);
     }
 

--- a/lib/CybsSoapClient.php
+++ b/lib/CybsSoapClient.php
@@ -10,9 +10,11 @@ include 'CybsClient.php';
 class CybsSoapClient extends CybsClient
 {
 
-    function __construct($options=array())
+    function __construct($options=array(), $properties=array())
     {
-        $properties = parse_ini_file('cybs.ini');
+        if (empty($properties)) {
+            $properties = parse_ini_file('cybs.ini');
+        }
         parent::__construct($options, $properties);
     }
 


### PR DESCRIPTION
Made changes to allow `$properties` to be passed to the construct method for `CybsSoapClient` and `CybsNameValuePairClient`.

If `$properties` is passed to the construct, it will be used instead of loading config from the cybs.ini. 